### PR TITLE
Confirmation modal

### DIFF
--- a/frontend/src/components/Lists/SingleList.js
+++ b/frontend/src/components/Lists/SingleList.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateList, deleteList } from '../../store/boards';
 import './SingleList.css';
+import ConfirmationModal from '../Modal/ConfirmationModal';
 
 export const SingleList = ({ list }) => {
     const dispatch = useDispatch();
@@ -93,12 +94,19 @@ export const SingleList = ({ list }) => {
                     <i className={`fa-solid fa-pen-to-square jello-wiggle ${titleDisplay}`} onClick={titleAndInputDisplay}></i>
                 </div>
                 <div className='del__bts__in__card'>
+
+                  <ConfirmationModal message="Are you sure you want to delete this list?"
+                                     actionButtonLabel="Delete List"
+                                     func={()=>removeList(list)}
+                                     active={list.cards.length > 0}> 
                     <button
                         className={`${titleDisplay} delete-list`}
-                        onClick={() => removeList(list)}
+                        //onClick={() => removeList(list)}
                     >
                         <div className={`close__text`}>&#215;</div>
                     </button>
+                  </ConfirmationModal>
+
                 </div>
             </div>
         </div>

--- a/frontend/src/components/Modal/ConfirmationModal.css
+++ b/frontend/src/components/Modal/ConfirmationModal.css
@@ -1,0 +1,16 @@
+
+.confirmation-modal {
+  padding: 25px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 25px;
+
+  background-color: var(--white-color);
+  border-radius: 5px;
+  box-shadow: var(--main-box-shadow);
+
+  animation: jello_3 1s;
+  cursor: default;
+}

--- a/frontend/src/components/Modal/ConfirmationModal.js
+++ b/frontend/src/components/Modal/ConfirmationModal.js
@@ -1,0 +1,45 @@
+import Modal from './index';
+import { useState } from 'react';
+import './ConfirmationModal.css';
+
+export default function ConfirmationModal({ message, actionButtonLabel, func, children, active }) {
+  const [ showModal, setShowModal ] = useState(false);
+
+  const conditionalActivation = e => {
+    if( active || active === undefined ) showModalFunc()
+    else func()
+  }
+
+  const showModalFunc = e => setShowModal(true);
+  const closeModalFunc = e => setShowModal(false);
+
+  const stopTheProp = e => e.stopPropagation();
+
+  const doAction = e => func();
+
+  const className = `
+  jello__wiggle
+  logout__button
+  red__button
+  button__shine__short__red`
+
+  return (
+    <>
+      <div onClick={conditionalActivation}>
+        {children}
+      </div>
+      { showModal && (
+        <Modal closeModalFunc={closeModalFunc}>
+          <div className='confirmation-modal'
+               onClick={stopTheProp}
+               onMouseDown={stopTheProp}>
+            <div className='confirmation-message'>{message}</div>
+            <div className='confirmation-buttons'>
+              <button onClick={doAction} id="logout-button" className={className}>{actionButtonLabel}</button>
+            </div>
+          </div>
+        </Modal>
+      )} 
+    </>
+  )
+}

--- a/frontend/src/components/Modal/Modal.css
+++ b/frontend/src/components/Modal/Modal.css
@@ -13,4 +13,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+
+    cursor: default;
 }

--- a/frontend/src/components/boards/OneBoard.js
+++ b/frontend/src/components/boards/OneBoard.js
@@ -5,6 +5,7 @@ import { readBoards, readOneBoard, deleteBoard } from '../../store/boards';
 import { UserIcon } from '../UserIcon';
 import ListsPage from '../Lists/Lists';
 import Modal from '../Modal';
+import ConfirmationModal from '../Modal/ConfirmationModal'
 import EditBoardForm from './EditBoardForm';
 import { ShareBoardForm } from './ShareBoardForm';
 import { avatars } from '../../context/Avatar';
@@ -144,7 +145,11 @@ const OneBoard = () => {
                                 <EditBoardForm closeModalFunc={closeEditModalFunc} />
                             </Modal>)}
 
-                            {board.user_id === user.id && (<button
+                            {board.user_id === user.id && (
+                            <ConfirmationModal message="Are you sure you want to delete this board?"
+                                               actionButtonLabel="Delete Board"
+                                               func={()=>deleteOneBoard(board)}>
+                              <button
                                 id='gray__board__button'
                                 className='
                                 jello__wiggle
@@ -152,9 +157,9 @@ const OneBoard = () => {
                                 red__button
                                 button__shine__short__red
                                 '
-                                onClick={() => {
-                                    deleteOneBoard(board)
-                                }}>Delete Board</button>
+                                //onClick={() => deleteOneBoard(board)}
+                              >Delete Board</button>
+                            </ConfirmationModal>
                             )}
                         </div>
                     </div>


### PR DESCRIPTION
This could be applied to other buttons, like the card delete button, but I am just going to leave it at this for now, so y'all can try it out.


Please feel free to change the padding / gap in `/components/Modal/ConfirmationModal.css`, I think it may look a little unproportionable at the moment.


The neat thing about it is that it manages its own showModal state, so the only thing you have to do to add it to a button is wrap the button in the component, and transfer the action to the wrapper.
![image](https://user-images.githubusercontent.com/18235032/167302029-42cc315f-df68-4232-998a-a4c5b293832d.png)
